### PR TITLE
had to downgrade kernel. intrerfaces names changed

### DIFF
--- a/T2_US_Caltech/Agent01/main.yaml
+++ b/T2_US_Caltech/Agent01/main.yaml
@@ -5,7 +5,7 @@ general:
   webdomain: "https://sense-caltechprod.nrp-nautilus.io:443"
   node_exporter: "transfer-11.ultralight.org:9100"
 agent: 
-  interfaces: [bondpublic, enp1s0np0]
+  interfaces: [bondpublic, enp1s0]
   hostname: transfer-11.ultralight.org
 bondpublic:
   port: Ethernet 1/1/1:1
@@ -32,7 +32,7 @@ bondpublic:
     - "fc00:0000:0800::/40"
     - "fc00:0000:0900::/40"
     - "fc00:0000:ff00::/40"
-enp1s0np0:
+enp1s0:
   port: Ethernet0
   switch: edgecore_s0
   shared: false

--- a/T2_US_Caltech/Agent07/main.yaml
+++ b/T2_US_Caltech/Agent07/main.yaml
@@ -5,7 +5,7 @@ general:
   webdomain: "https://sense-caltechprod.nrp-nautilus.io:443"
   node_exporter: "transfer-17.ultralight.org:9100"
 agent: 
-  interfaces: [bondpublic, enp1s0np0]
+  interfaces: [bondpublic, enp1s0]
   hostname: transfer-17.ultralight.org
 bondpublic:
   port: Ethernet 1/1/7
@@ -32,7 +32,7 @@ bondpublic:
     - "fc00:0000:0800::/40"
     - "fc00:0000:0900::/40"
     - "fc00:0000:ff00::/40"
-enp1s0np0:
+enp1s0:
   port: Ethernet176
   switch: edgecore_s0
   shared: false

--- a/T2_US_Caltech/Agent08/main.yaml
+++ b/T2_US_Caltech/Agent08/main.yaml
@@ -5,7 +5,7 @@ general:
   webdomain: "https://sense-caltechprod.nrp-nautilus.io:443"
   node_exporter: "transfer-18.ultralight.org:9100"
 agent: 
-  interfaces: [bondpublic, enp1s0np0]
+  interfaces: [bondpublic, enp1s0]
   hostname: transfer-18.ultralight.org
 bondpublic:
   port: Ethernet 1/1/8
@@ -32,7 +32,7 @@ bondpublic:
     - "fc00:0000:0800::/40"
     - "fc00:0000:0900::/40"
     - "fc00:0000:ff00::/40"
-enp1s0np0:
+enp1s0:
   port: Ethernet184
   switch: edgecore_s0
   shared: false


### PR DESCRIPTION
Kernel v6.12 dropped support for CGROUPS. 
As we build nodes from elrepo with kernel-ml, k8s stopped working. 
As a temporary measure nodes were build with stock EL8 that is v4. Interface names changed. 
We will make permanent fix for interfaces names once we switch to EL9 that has newer network stack. 