### PR TITLE
Interface names correction for Caltech

### DIFF
--- a/T2_US_Caltech/Agent01/main.yaml
+++ b/T2_US_Caltech/Agent01/main.yaml
@@ -5,7 +5,7 @@ general:
   webdomain: "https://sense-caltechprod.nrp-nautilus.io:443"
   node_exporter: "transfer-11.ultralight.org:9100"
 agent: 
-  interfaces: [bondpublic, enp1s0]
+  interfaces: [bondpublic, enp1s0np0]
   hostname: transfer-11.ultralight.org
 bondpublic:
   port: Ethernet 1/1/1:1
@@ -32,7 +32,7 @@ bondpublic:
     - "fc00:0000:0800::/40"
     - "fc00:0000:0900::/40"
     - "fc00:0000:ff00::/40"
-enp1s0:
+enp1s0np0:
   port: Ethernet0
   switch: edgecore_s0
   shared: false

--- a/T2_US_Caltech/Agent07/main.yaml
+++ b/T2_US_Caltech/Agent07/main.yaml
@@ -5,7 +5,7 @@ general:
   webdomain: "https://sense-caltechprod.nrp-nautilus.io:443"
   node_exporter: "transfer-17.ultralight.org:9100"
 agent: 
-  interfaces: [bondpublic, enp1s0]
+  interfaces: [bondpublic, enp1s0np0]
   hostname: transfer-17.ultralight.org
 bondpublic:
   port: Ethernet 1/1/7
@@ -32,7 +32,7 @@ bondpublic:
     - "fc00:0000:0800::/40"
     - "fc00:0000:0900::/40"
     - "fc00:0000:ff00::/40"
-enp1s0:
+enp1s0np0:
   port: Ethernet176
   switch: edgecore_s0
   shared: false

--- a/T2_US_Caltech/Agent08/main.yaml
+++ b/T2_US_Caltech/Agent08/main.yaml
@@ -5,7 +5,7 @@ general:
   webdomain: "https://sense-caltechprod.nrp-nautilus.io:443"
   node_exporter: "transfer-18.ultralight.org:9100"
 agent: 
-  interfaces: [bondpublic, enp1s0]
+  interfaces: [bondpublic, enp1s0np0]
   hostname: transfer-18.ultralight.org
 bondpublic:
   port: Ethernet 1/1/8
@@ -32,7 +32,7 @@ bondpublic:
     - "fc00:0000:0800::/40"
     - "fc00:0000:0900::/40"
     - "fc00:0000:ff00::/40"
-enp1s0:
+enp1s0np0:
   port: Ethernet184
   switch: edgecore_s0
   shared: false


### PR DESCRIPTION
We found out that linux NIC names were changed due misconfiguration.

200G cards were replaced by 400G, and udev rules based on MAC were not updated.
 
All 400G NICs are enp1s0np0 for now till it will be renamed into something more human friendly after upgrade to EL9