### PR TITLE
New ports for SC25 main.yaml

### DIFF
--- a/T2_US_Caltech/FE/main.yaml
+++ b/T2_US_Caltech/FE/main.yaml
@@ -92,6 +92,8 @@ edgecore_s0:
     Ethernet92: {}
     Ethernet96: {}
     Ethernet100: {}
+    Ethernet160: {}
+    Ethernet168: {}
     PortChannel41:
       capacity: 200000
       desttype: switch


### PR DESCRIPTION
Adding ports Ethernet160 (21) and Ethernet168 (22) to connect to Caltech servers